### PR TITLE
refactor(navItems): use same markup as flarum/core

### DIFF
--- a/js/src/forum/extendUserPage.tsx
+++ b/js/src/forum/extendUserPage.tsx
@@ -13,7 +13,6 @@ export default function extendUserPage() {
         <LinkButton
           href={app.route('user.signature', { username: this.user?.username() })}
           icon="fas fa-signature"
-          class="Button Button--link hasIcon"
         >
           {app.translator.trans('signature.forum.buttons.signature')}
         </LinkButton>,


### PR DESCRIPTION
Summary:
- Remove classes of the new LinkButton to match the markup of other Buttons in the side navigation on the Users Page stemming from flarum/core 