### PR TITLE
Implement setting if inline editing is allowed

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -27,7 +27,8 @@ return [
     (new Extend\Settings())
         ->default('signature.maximum_char_limit', 500)
         ->default('signature.maximum_image_count', 2)
-        ->serializeToForum('allowInlineEditing', 'signature.allow_inline_editing', 'boolval', false),
+        ->default('signature.allow_inline_editing', false)
+        ->serializeToForum('allowInlineEditing', 'signature.allow_inline_editing', 'boolval'),
 
     (new Extend\Model(User::class))
         ->cast('signature', 'string'),

--- a/extend.php
+++ b/extend.php
@@ -26,7 +26,8 @@ return [
 
     (new Extend\Settings())
         ->default('signature.maximum_char_limit', 500)
-        ->default('signature.maximum_image_count', 2),
+        ->default('signature.maximum_image_count', 2)
+        ->serializeToForum('enableInlineEditing', 'signature.inline_editing', 'boolval', false),
 
     (new Extend\Model(User::class))
         ->cast('signature', 'string'),

--- a/extend.php
+++ b/extend.php
@@ -27,7 +27,7 @@ return [
     (new Extend\Settings())
         ->default('signature.maximum_char_limit', 500)
         ->default('signature.maximum_image_count', 2)
-        ->serializeToForum('enableInlineEditing', 'signature.inline_editing', 'boolval', false),
+        ->serializeToForum('allowInlineEditing', 'signature.allow_inline_editing', 'boolval', false),
 
     (new Extend\Model(User::class))
         ->cast('signature', 'string'),

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -15,6 +15,12 @@ app.initializers.add('katosdev-signature', () => {
       label: app.translator.trans('signature.admin.settings.maximum_char_limit.description'),
       help: app.translator.trans('signature.admin.settings.maximum_char_limit.help'),
     })
+    .registerSetting({
+      setting: 'signature.inline_editing',
+      type: 'boolean',
+      label: app.translator.trans('signature.admin.settings.inline_editing.description'),
+      help: app.translator.trans('signature.admin.settings.inline_editing.help'),
+    })
     .registerPermission(
       {
         permission: 'moderateSignature',

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -16,10 +16,10 @@ app.initializers.add('katosdev-signature', () => {
       help: app.translator.trans('signature.admin.settings.maximum_char_limit.help'),
     })
     .registerSetting({
-      setting: 'signature.inline_editing',
+      setting: 'signature.allow_inline_editing',
       type: 'boolean',
-      label: app.translator.trans('signature.admin.settings.inline_editing.description'),
-      help: app.translator.trans('signature.admin.settings.inline_editing.help'),
+      label: app.translator.trans('signature.admin.settings.allow_inline_editing.description'),
+      help: app.translator.trans('signature.admin.settings.allow_inline_editing.help'),
     })
     .registerPermission(
       {

--- a/js/src/forum/components/Signature.tsx
+++ b/js/src/forum/components/Signature.tsx
@@ -34,7 +34,7 @@ export default class Signature extends Component<SignatureAttrs> {
     );
   }
   renderEditor() {
-    if (this.user.canEditSignature()) {
+    if (this.user.canEditSignature() && !this.attrs.readonly) {
       return (
         <div class="SignatureEditor">
           <TextEditor
@@ -63,7 +63,7 @@ export default class Signature extends Component<SignatureAttrs> {
   }
 
   edit() {
-    if (this.user.canEditSignature()) {
+    if (this.user.canEditSignature() && !this.attrs.readonly) {
       this.signatureState.toggleEditing();
       m.redraw();
     }

--- a/js/src/forum/extendCommentPost.tsx
+++ b/js/src/forum/extendCommentPost.tsx
@@ -7,7 +7,7 @@ export default function extendCommentPost() {
   extend(CommentPost.prototype, 'content', function (content) {
     if (this.attrs.post.user?.()) {
       if (this.attrs.post.user().signature()) {
-        const allowInlineEditing = app.forum.attribute('enableInlineEditing') || false;
+        const allowInlineEditing = app.forum.attribute('allowInlineEditing') || false;
 
         content.push(
           <div className="Post-signature">

--- a/js/src/forum/extendCommentPost.tsx
+++ b/js/src/forum/extendCommentPost.tsx
@@ -1,3 +1,4 @@
+import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
 import CommentPost from 'flarum/forum/components/CommentPost';
 import Signature from './components/Signature';
@@ -6,9 +7,11 @@ export default function extendCommentPost() {
   extend(CommentPost.prototype, 'content', function (content) {
     if (this.attrs.post.user?.()) {
       if (this.attrs.post.user().signature()) {
+        const allowInlineEditing = app.forum.attribute('enableInlineEditing') || false;
+
         content.push(
           <div className="Post-signature">
-            <Signature user={this.attrs.post.user()} readonly={true} />
+            <Signature user={this.attrs.post.user()} readonly={!allowInlineEditing} />
           </div>
         );
       }

--- a/js/src/forum/extendUserPage.tsx
+++ b/js/src/forum/extendUserPage.tsx
@@ -13,7 +13,6 @@ export default function extendUserPage() {
         <LinkButton
           href={app.route('user.signature', { username: this.user?.username() })}
           icon="fas fa-signature"
-          class="Button Button--link hasIcon"
         >
           {app.translator.trans('signature.forum.buttons.signature')}
         </LinkButton>,

--- a/js/src/forum/extendUserPage.tsx
+++ b/js/src/forum/extendUserPage.tsx
@@ -13,6 +13,7 @@ export default function extendUserPage() {
         <LinkButton
           href={app.route('user.signature', { username: this.user?.username() })}
           icon="fas fa-signature"
+          class="Button Button--link hasIcon"
         >
           {app.translator.trans('signature.forum.buttons.signature')}
         </LinkButton>,

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -20,6 +20,6 @@ signature:
             maximum_char_limit:
                 description : Maximum character limit of signature.
                 help: When the user exceeds the maximum character limit in their signature, they will be prevented from saving until the character count is accordingly.
-            inline_editing:
+            allow_inline_editing:
                 description : Inline editing of signature.
                 help: When enabled, users can edit their signature while viewing a post.

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -20,3 +20,6 @@ signature:
             maximum_char_limit:
                 description : Maximum character limit of signature.
                 help: When the user exceeds the maximum character limit in their signature, they will be prevented from saving until the character count is accordingly.
+            inline_editing:
+                description : Inline editing of signature.
+                help: When enabled, users can edit their signature while viewing a post.


### PR DESCRIPTION
While testing version 1.5 I noticed that it's possible to edit the Signature while viewing posts (for example in the all discussions page). First I assumed this is a feature but quickly discovered that a `readonly` property exists and that it's not being used.

Summary:
- Implement new setting if inline editing should be allowed.
- Check in `extendCommentPost` if inline editing is allowed and pass `true` or `false` accordingly

Notes:
- I wasn't set how to name various "things" so feel free to change the terminology :) 