### PR TITLE
fix(routing): use slug for routing

### DIFF
--- a/js/src/forum/extendUserPage.tsx
+++ b/js/src/forum/extendUserPage.tsx
@@ -11,7 +11,7 @@ export default function extendUserPage() {
       items.add(
         'signature',
         <LinkButton
-          href={app.route('user.signature', { username: this.user?.username() })}
+          href={app.route('user.signature', { username: this.user?.slug() })}
           icon="fas fa-signature"
           class="Button Button--link hasIcon"
         >


### PR DESCRIPTION
Summary:
- Use slug instead of username to ensure compatibility no matter if the slug driver is left to default or id.

Notes:
- While testing I noticed that other "third-party" extensions also use `username` instead of `slug` for `LinkButton` in the Side Navigation on the users page, for example:
- - fof/upload
- - imorland/follow-users

I assume there are also other extensions which don't use the slug, as Flarum first party extensions do.